### PR TITLE
Simplifies extractReducer

### DIFF
--- a/src/Control/Monad/Eff/Redux/Redux.js
+++ b/src/Control/Monad/Eff/Redux/Redux.js
@@ -104,17 +104,10 @@ var compose = function(){
 
 //INTERNALS
 
-//-----------------------------------------------------------------------------------------------
-//This is ugly but we must somehow 'extract' the two interleaved functions to create one plain JS
-//function with two parameters. PureScript's functions never have more than one parameter.
-//-----------------------------------------------------------------------------------------------
 var extractReducer = function(reducer){
-  var body     = reducer().toString();
-  var arg1     = reducer.toString().split(')',1)[0].replace(/\s/g,'').substr(9).split(',');
-  var arg2     = body.split(')',1)[0].replace(/\s/g,'').substr(9).split(',');
-  var tmp      = body.slice(body.indexOf("{") + 1, body.lastIndexOf("}"));
-  var _reducer = new Function(arg1, arg2, tmp);
-  return _reducer;
+  return function(a, b) {
+      return reducer(a)(b)
+  }
 };
 //The `next` call is the dispatcher call and by defaul PureScript puts an additional ()-call after
 //its completion (this is how PureScript wrapps effects from JS side). To maintain this extra call


### PR DESCRIPTION
The previous version of extractReducer breaks the scope of the reducer.
When it gets evaled there is no guarantee that the variables referenced
in the body of the reducer are in scope.

With the new approach, the reducer is used as a normal function, so it
retains all of the variables that it has closed over.
